### PR TITLE
add bokeh demo to Develop menu

### DIFF
--- a/kernels/python/casadesk/trybokeh.py
+++ b/kernels/python/casadesk/trybokeh.py
@@ -1,0 +1,12 @@
+import numpy as np
+from bokeh.plotting import figure, show
+
+def bokehdemo01( ):
+    N=4000
+    x = np.random.random(size=N) * 100
+    y = np.random.random(size=N) * 100
+    radii = np.random.random(size=N) * 1.5
+    colors = ["#%02x%02x%02x" % ( r, g, 150 ) for r, g in zip( np.floor(50+2*x).astype(np.int16), np.floor(30+2*y).astype(np.int16) )]
+    p = figure( )
+    p.circle( x, y, radius=radii, fill_color=colors, fill_alpha=0.6, line_color=None )
+    show(p)

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@types/lodash.clonedeep": "^4.5.6",
     "@types/react": "^17.0.3",
     "@types/react-dom": "^17.0.3",
+    "@types/underscore": "^1.11.2",
     "@types/uuid": "^8.3.0",
     "copyfiles": "^2.4.1",
     "electron": "^12.0.2",
@@ -44,6 +45,7 @@
     "prop-types": "^15.7.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "underscore": "^1.13.1",
     "uuid": "^8.3.2",
     "zeromq": "^5.2.8"
   }

--- a/src/demo/bokeh.html
+++ b/src/demo/bokeh.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Electron React, TypeScript and Bokeh Example</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script>
+      require("./bokeh.js")
+    </script>
+  </body>
+</html>

--- a/src/demo/bokeh.tsx
+++ b/src/demo/bokeh.tsx
@@ -1,0 +1,119 @@
+import * as path from 'path';
+import React, { useState, useEffect } from "react"
+import * as ReactDOM from "react-dom"
+import PropTypes from 'prop-types';
+import { parse } from 'node-html-parser';
+import { ipcRenderer } from 'electron';
+import { Dictionary } from "../utils";
+import { JupyterKernel, message_type } from "../kernels";
+import _, { map } from 'underscore';
+
+var root = path.dirname(path.dirname(path.resolve(__dirname)))
+
+var kernel: JupyterKernel = new JupyterKernel( )
+
+const MIME_HTML = 'text/html'
+const MIME_HOLO_JSON = 'application/vnd.holoviews_load.v0+json'
+const MIME_JAVASCRIPT = 'application/javascript'
+
+function splitScripts( output: any[] ): {html: string, scripts: string[]} {
+    let html = ''
+    let scripts = [] as string[]
+    output.forEach( elem => {
+        if ( elem.content !== undefined &&
+             elem.content.data !== undefined &&
+             elem.content.data[MIME_HTML] !== undefined ) {
+            const root = parse(elem.content.data[MIME_HTML])
+            const script_elements = root.querySelectorAll('script')
+            scripts = script_elements.map(e => e.text)
+            script_elements.map(e => e.remove( ))
+            html = root.toString( )
+        }
+    } )
+    return { html, scripts }
+}
+
+
+function Bokeh01( ) {
+    const [html, setHtml] = useState('Loading plot...')
+    const [scripts, setScripts] = useState([ ] as string[])
+    const [javascript, setJavascript] = useState([ ] as string[])
+
+    useEffect(( ) => {
+        if ( scripts.length > 0 ) {
+            scripts.map(s => { window.eval(s) } )
+            setScripts([ ] as string[])
+        }
+    },[scripts])
+
+    useEffect( ( ) => {
+        if ( javascript.length > 0 ) {
+            javascript.map(s => { window.eval(s) })
+            setJavascript([ ] as string[])
+        }
+    },[javascript])
+
+    useEffect(( ) => {
+        const createPlot = async ( ) => {
+            let code = `from casadesk.trybokeh import bokehdemo01
+bokehdemo01( )`
+
+            let result = await kernel.call( "execute_request" as message_type,
+                                            { silent: true,
+                                              code } ).then(
+                                                  res => _.groupBy(res, x => x.content.type)
+                                              )
+
+
+
+            if ( result.html != undefined ) {
+                let splithtml = splitScripts(result.html)
+                setHtml(splithtml.html)
+                setScripts(splithtml.scripts)
+            }
+
+            if ( result.javascript != undefined ) {
+                setJavascript(_.map(result.javascript, js => js.content.data['application/javascript']))
+            }
+        }
+        createPlot( )
+    }, [])
+
+    return <div>
+               <div dangerouslySetInnerHTML={{ __html: html }} />
+           </div>
+}
+
+async function initializeBokeh( spec: any  ) {
+    // Bokeh must be initialized for notebook display...
+    let code = `from bokeh.io import output_notebook
+output_notebook( )`
+    let result = await kernel.call( "execute_request" as message_type,
+                                    { silent: true, code } ).then(
+                                        res => _.groupBy(res, x => x.content.type)
+                                    )
+    if ( result.javascript != undefined ) {
+        result.javascript.forEach( js => {
+            window.eval(js.content.data['application/javascript'])
+        } )
+    }
+                        
+    if ( result.html != undefined ) {
+        let splithtml = splitScripts(result.html)
+        splithtml.scripts.forEach( script => {
+            window.eval(script)
+        })
+    }
+    return spec
+}
+
+ipcRenderer.send('kernel-request', { name: 'bokeh' })
+ipcRenderer.once('kernel-reply', (ev,spec) => {
+    console.info("received kernel info",spec)
+    kernel.attach(spec).then(initializeBokeh).then( spec => {
+        ReactDOM.render(<Bokeh01/>,document.getElementById("app"))
+    } )
+    window.onbeforeunload = (e: any) => {
+        ipcRenderer.send('kernel-release', { session: spec.header.session } )
+    }
+} )

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,16 +2,14 @@ import { app, BrowserWindow, globalShortcut, Menu, MenuItem, ipcMain } from "ele
 import { JupyterKernel } from "./kernels";
 const { v4: uuidv4 } = require('uuid');
 import * as path from 'path';
-
-interface Dictionary {
-    [key: string]: any
-}
+import { Dictionary } from "./utils";
 
 // These windows variables need to be cleaned up and managed instead of
 // being global variables, but for now...
 // ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
 let placeholderWindow: any
 let plotlyDemo: any
+let bokehDemo: any
 // ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
 
 let kernelSpec: Promise<any>
@@ -108,6 +106,22 @@ function setupDevAndDemo( devmenu: Menu ) {
             plotlyDemo.loadFile(`./dist/demo/plotly.html`)
         }
     }))
+    devmenu.append(new MenuItem({
+        label: 'Bokeh Demo',
+        click: ( ) => {
+            bokehDemo = new BrowserWindow({
+                width: 800,
+                height: 600,
+                webPreferences: {
+                    nodeIntegration: true, // this line is very important as it allows us to use `require` syntax in our html file.
+                    contextIsolation: false,
+                },
+            })
+
+            bokehDemo.loadFile(`./dist/demo/bokeh.html`)
+        }
+    }))
+
 }
 function initializeApp() {
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,10 @@
 import { cloneDeep } from "lodash";
 export const deep_copy = cloneDeep;
 
+export interface Dictionary {
+  [key: string]: any
+}
+
 // returns the number of keys of an object, e.g., {a:5, b:7, d:'hello'} --> 3
 export function len(obj: object | undefined | null): number {
   if (obj == null) {


### PR DESCRIPTION
Hey @jrhosk
These are the changes for adding the Bokeh demo to the `Develop` menu. The only change that is noteworthy is the addition of a `type` field to the Jupyter messages returned by the `call(...)` function and the addition of the `underscore` package. These allow `groupBy` to be used to organize the messages for processing:
```
let result = await kernel.call( "execute_request" as message_type,
                                { silent: true,
                                  code } ).then(
                                      res => _.groupBy(res, x => x.content.type)
                                  )
```
If these look good to you, please merge them... thanks!