### PR TITLE
Try building documentation with Sphinx 4

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx==3.4.3
+sphinx~=4.0
 casadata
 casatools
 bokeh


### PR DESCRIPTION
Hi! Juan Luis from Read the Docs here. This comes from https://github.com/sphinx-doc/sphinx/issues/9393

As I tried reproducing locally but didn't succeed, and also the logs with Sphinx 3 and Sphinx 4 look identical on RTD but we cannot see the old builds anymore, I am sending this pull request so we can see how the documentation looks like. The idea is that, if you haven't done so already, you can enable our PR builder and preview the documentation, see here for more info:

https://blog.readthedocs.com/pull-request-builder-general-availability/